### PR TITLE
Implementación de Endpoints GET, POST para"Proyectos"

### DIFF
--- a/src/app/api/project/route.ts
+++ b/src/app/api/project/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { projectController } from '@/backend/controllers/project';
+
+
+/**
+ * Get all projects
+ * @param req - The NextRequest object.
+ * @returns A NextResponse object with all projects data or an error message.
+ */
+export async function GET(
+    req: NextRequest,
+  ) {
+    try {
+      const allProjects = await projectController.get_all_projects(req);
+      return NextResponse.json(allProjects, { status: 200 });
+    } catch (err: any) {
+      const error_json = {
+        error_message: err.error_message,
+        error_message_detail: err.error_message_detail,
+        error_code: err.error_code,
+      };
+      return NextResponse.json(error_json, { status: err.status });
+    }
+  }
+
+/**
+ * Create a new project
+ * @param req - The NextRequest object containing the request details.
+ * @returns A NextResponse object with the created project data or an error message.
+ */
+  export async function POST(
+    req: NextRequest,
+  ) {
+    try {
+      const project = await projectController.create_project(req);
+      return NextResponse.json(project, { status: 200 });
+    } catch (err: any) {
+      const error_json = {
+        error_message: err.error_message,
+        error_message_detail: err.error_message_detail,
+        error_code: err.error_code,
+      };
+      return NextResponse.json(error_json, { status: err.status });
+    }
+  }
+

--- a/src/backend/controllers/project.ts
+++ b/src/backend/controllers/project.ts
@@ -67,7 +67,66 @@ const delete_project = async (
   }
 };
 
+/**
+ * Retrieve all projects
+ * 
+ * @param req - The NextRequest object containing the request details.
+ * @returns An object with the list of projects or throws a custom error.
+ * @throws {custom_error} If an error occurs during the get process.
+ */
+const get_all_projects = async (
+  req: NextRequest
+) => {
+  try {
+    const projects = await projectService.get_all_projects();
+    return { projects };
+  } catch (error: any) {
+    const handle_err: error_object = handle_error_http_response(error, '0000');
+    throw new custom_error(
+      handle_err.error_message,
+      handle_err.error_message_detail,
+      handle_err.error_code,
+      handle_err.status
+    );
+  }
+};
+
+/**
+ * Create a new project
+ * @param req - The NextRequest object containing the request details and body.
+ * @returns The created project object or throws a custom error.
+ * @throws {custom_error} If an error occurs during the create process.
+ */
+const create_project = async (
+  req: NextRequest
+) => {
+  try {
+    const body = await req.json()
+
+    if (body.start) {
+      body.start = new Date(body.start);
+    }
+    if (body.end) {
+      body.end = new Date(body.end);
+    }
+
+    const data = projectValidator.validator_project_create(body);
+    const project = await projectService.create_project(data);
+    return project;
+  } catch (error: any) {
+    const handle_err: error_object = handle_error_http_response(error, '0000');
+    throw new custom_error(
+      handle_err.error_message,
+      handle_err.error_message_detail,
+      handle_err.error_code,
+      handle_err.status
+    );
+  }
+};
+
 export const projectController = {
   update_project,
-  delete_project
+  delete_project,
+  get_all_projects,
+  create_project,
 };

--- a/src/backend/interfaces/project.ts
+++ b/src/backend/interfaces/project.ts
@@ -3,3 +3,9 @@ export interface ProjectUpdateInput {
   start?: Date;
   end?: Date;
 }
+
+export interface ProjectCreateInput {
+  description?: string;
+  start?: Date;
+  end?: Date;
+}

--- a/src/backend/interfaces/project.ts
+++ b/src/backend/interfaces/project.ts
@@ -5,7 +5,7 @@ export interface ProjectUpdateInput {
 }
 
 export interface ProjectCreateInput {
-  description?: string;
-  start?: Date;
-  end?: Date;
+  description: string;
+  start: Date;
+  end: Date;
 }

--- a/src/backend/services/project.ts
+++ b/src/backend/services/project.ts
@@ -1,5 +1,5 @@
 import prisma from '../../../prisma/prisma';
-import { ProjectUpdateInput } from '../interfaces/project';
+import { ProjectUpdateInput, ProjectCreateInput } from '../interfaces/project';
 
 /**
  * Updates a project with the specified ID.
@@ -50,7 +50,36 @@ export const delete_project = async (id: number) => {
   }
 };
 
+/**
+ * Retrieve all projects
+ * @returns A promise that resolves to an array of project objects.
+ */
+export const get_all_projects = async () => {
+  try {
+    const projects = await prisma.project.findMany();
+    return projects;
+  } catch (error) {
+    throw error;
+  }
+};
+
+/**
+ * Create a new project
+ * @param data - The project data to create a new project.
+ * @returns A promise that resolves to the created project object.
+ */
+export const create_project = async (data: ProjectCreateInput) => {
+  try {
+    const project = await prisma.project.create({ data });
+    return project;
+  } catch (error) {
+    throw error;
+  }
+};
+
 export const projectService = {
   update_project,
   delete_project,
+  get_all_projects,
+  create_project,
 };

--- a/src/backend/validators/project.ts
+++ b/src/backend/validators/project.ts
@@ -14,7 +14,19 @@ const project_update_object_body = z.object({
   message: "El tiempo de inicio debe ser menor al tiempo de fin",
 });
 
+const project_create_object_body = z.object({
+  description: z.string(),
+  start: z.date(),
+  end: z.date(),
+}).refine(data => {
+  return data.start < data.end;
+}, {
+  // Mensaje de error personalizado
+  message: "El tiempo de inicio debe ser menor al tiempo de fin",
+});
+
 export type TProject_update_object_body = z.infer<typeof project_update_object_body>;
+export type TProject_create_object_body = z.infer<typeof project_create_object_body>;
 
 /**
  * Validates the update body of a project.
@@ -26,6 +38,12 @@ export const validator_project_update = (body: unknown) => {
   return its_validated;
 };
 
+export const validator_project_create = (body: any) => {
+  const its_validated = project_create_object_body.parse(body)
+  return its_validated
+}
+
 export const projectValidator = {
   validator_project_update,
+  validator_project_create
 };


### PR DESCRIPTION
Se implementaron los endpoints `GET` y `POST` en `http://localhost:3000/api/project` para crear y obtener todos los proyectos. 

### Notas:
- **Validación**: No se está realizando validación sobre qué usuario está creando el proyecto; cualquier usuario puede crear un proyecto.
- **POST Body**: El método `POST` recibe un cuerpo con la siguiente estructura:
  ```json
  {
    "description": "Nueva descripción del proyecto",
    "start": "2022-02-01",
    "end": "2022-12-31"
  }
  ```
  - Todos los atributos son obligatorios.
  - `start` debe ser menor que `end`.