### PR TITLE
Add GET route to retrieve project by ID

### DIFF
--- a/src/app/api/project/[id]/route.ts
+++ b/src/app/api/project/[id]/route.ts
@@ -26,6 +26,24 @@ export async function PUT(
   }
 }
 
+export async function GET(
+  req: NextRequest,
+  params: { params: { id: string } }
+) {
+  try {
+    const projects = await projectController.get_project_by_id(req, params);
+    return NextResponse.json(projects, { status: 200 });
+  } catch (err: any) {
+    const error_json = {
+      error_message: err.error_message,
+      error_message_detail: err.error_message_detail,
+      error_code: err.error_code,
+    };
+    return NextResponse.json(error_json, { status: err.status });
+  }
+}
+
+
 /**
  * Deletes a project based on the provided ID.
  * @param req - The NextRequest object.

--- a/src/backend/controllers/project.ts
+++ b/src/backend/controllers/project.ts
@@ -134,9 +134,28 @@ const create_project = async (
   }
 };
 
+const get_project_by_id = async (
+  req: NextRequest,
+  { params }: { params: { id: string } }) => {
+  try {
+    let id = parseInt(params.id);
+    const project = await projectService.get_project_by_id(id);
+    return project;
+  } catch (error: any) {
+    const handle_err: error_object = handle_error_http_response(error, '0011');
+    throw new custom_error(
+      handle_err.error_message,
+      handle_err.error_message_detail,
+      handle_err.error_code,
+      handle_err.status
+    );
+  }
+}
+
 export const projectController = {
   update_project,
   delete_project,
   get_all_projects,
   create_project,
+  get_project_by_id
 };

--- a/src/backend/services/project.ts
+++ b/src/backend/services/project.ts
@@ -144,9 +144,26 @@ export const create_project = async (data: ProjectCreateInput) => {
   }
 };
 
+export const get_project_by_id = async (id: number) => {
+  try {
+    const project = await prisma.project.findFirst({
+      where: {
+        id: id,
+        status: {
+          in: ['ACTIVE', 'INACTIVE'],
+        },
+      },
+    });
+    return project;
+  } catch (error) {
+    throw error;
+  }
+}
+
 export const projectService = {
   update_project,
   delete_project,
   get_all_projects,
   create_project,
+  get_project_by_id,
 };


### PR DESCRIPTION
This pull request adds a new GET route to retrieve a project by its ID. The route is implemented in the projectController and projectService files. The new route allows clients to fetch a specific project by providing its ID as a parameter. This feature enhances the functionality of the API by providing a way to retrieve individual projects.